### PR TITLE
Add `.flake8` config file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+ignore = W605

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,3 @@ jobs:
           python-version: "3.8.0"
       - name: flake8 Lint
         uses: py-actions/flake8@v2
-        with:
-          ignore: W605
-          # W605 - invalid escape sequence. escaped sequences are part of the web of science data i.e., '\&' is returned as part of the response

--- a/tests/report_handler/test_report_handler.py
+++ b/tests/report_handler/test_report_handler.py
@@ -56,14 +56,14 @@ class TestReportHandler(unittest.TestCase):
 
         # Reading the generated reporting and adding assertion checks
         for file in os.listdir("test_logs"):
-            excel = pd.read_excel("test_logs/"+file, None)
+            excel = pd.read_excel("test_logs/" + file, None)
 
             # Checks if two sheets generated
             sheets = len(excel.keys())
             self.assertEqual(2, sheets)
 
             # Removes files to avoid duplicate logging
-            os.remove("test_logs/"+file)
+            os.remove("test_logs/" + file)
 
         # Remove the Log file
         open("test_log.log", 'w').close()
@@ -73,7 +73,7 @@ class TestReportHandler(unittest.TestCase):
 
         # Reading the generated reporting and adding assertion checks
         for file in os.listdir("test_logs"):
-            excel = pd.read_excel("test_logs/"+file, None)
+            excel = pd.read_excel("test_logs/" + file, None)
 
             # Gets the data from DEBUG sheet and check if logs as expected
             debug_data = excel["DEBUG"].values.flatten().tolist()
@@ -88,7 +88,7 @@ class TestReportHandler(unittest.TestCase):
                 list(unique_debug_data))
 
             # Removes files to avoid duplicate logging
-            os.remove("test_logs/"+file)
+            os.remove("test_logs/" + file)
 
         # Remove the Log file
         open("test_log.log", 'w').close()


### PR DESCRIPTION
Fixes #15. This PR adds a `.flake8` config file to be the single source of configuration for flake8 instead of having configurations in both `settings.json` and in `lint.yml`.

To verify if this works:
1. Check that the automated checks pass (lint & unit tests)