### PR TITLE
Adds verbose flag

### DIFF
--- a/src/report_handler/report_handler.py
+++ b/src/report_handler/report_handler.py
@@ -8,10 +8,19 @@ import report_handler.utils as utils
 
 class ReportHandler(logging.Handler):
 
-    def __init__(self):
+    def __init__(self, verbose: bool = False):
+        """Creates an instance of ReportHandler
+
+        Args:
+            verbose (bool, optional): Enabling verbose will capture all log level entries without
+            needing to provide the `extra` arg in logging calls. For example, calling
+            `logging.debug(msg="debug message")` followed by `report_handler.write_report()`
+            will generate a xlsx with a `DEBUG` sheet. Defaults to False.
+        """
         logging.Handler.__init__(self)
         self.name = 'ReportHandler'
         self.logs = {}
+        self.verbose = verbose
 
     def add_entry_to_sheet(self, sheet, entry):
         if sheet not in self.logs:
@@ -132,16 +141,17 @@ class ReportHandler(logging.Handler):
         Returns:
             None
         """
-        # Only process if report_handler key is present
-        if "report_handler" not in record.__dict__.keys():
-            return
-
         if not hasattr(self, "start_time"):
             self.start_time = datetime.utcnow()
 
-        # Add entry to levelname
-        self.add_entry_to_sheet(sheet=record.levelname,
-                                entry=self._clean_record_msg(record.msg))
+        if self.verbose is True or "report_handler" in record.__dict__.keys():
+            # Add entry to levelname
+            self.add_entry_to_sheet(sheet=record.levelname,
+                                    entry=self._clean_record_msg(record.msg))
+
+        # Only adding to additional sheets if report_handler key is present
+        if "report_handler" not in record.__dict__.keys():
+            return
 
         entry, sheet = utils.retrieve_data_and_sheet_name(
             record.__dict__["report_handler"])


### PR DESCRIPTION
**What does this change do?** 

This change adds a verbose parameter to `ReportHandler`. This parameter defaults to `False` and can be set with:
> `report_handler = ReportHandler(verbose=True)`

**Why was this change made?** 

This change was made to improve support generating reports without the need for providing the `extra` argument in logging calls i.e., `logging.debug(msg="msg", extra={})`. This feature does not introduce any breaking changes.

## Verification

_List the steps needed to make sure this thing works. Be precise._

1. Verify the logic of the `test_correct_sheets_generated_with_verbose` test is sound.
2. Verify that all automated tests pass

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I have added docstrings with details on keyword arguments to new functions following the convention detailed in this [gist](https://gist.github.com/mbentz-uf/0433c32f260a0a06f57a9ff32fcef252)
* [x] I have added type hinting to new function parameters.
* [x] I have added tests to new functions, following the rules of [F.I.R.S.T.](https://wiki.ctsi.ufl.edu/books/testing/page/how-to-write-python-unit-tests).
* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
